### PR TITLE
Fixed wrong constant names in generated hasAddressChanged() method

### DIFF
--- a/src/GeocodableBehavior.php
+++ b/src/GeocodableBehavior.php
@@ -176,7 +176,7 @@ class GeocodableBehavior extends \Propel\Generator\Model\Behavior
             $columns = array();
             foreach (explode(',', $this->getParameter('address_columns')) as $col) {
                 if ($column = $this->getTable()->getColumn(trim($col))) {
-                    $columns[$column->getConstantName()] = $column->getPhpName();
+                    $columns[$builder->getColumnConstant($column)] = $column->getPhpName();
                 }
             }
 


### PR DESCRIPTION
Before:
Generated code for `hasAddressChanged()`:
```php
/**
 * Check whether the address of this object has changed.
 *
 * @return boolean
 */
public function hasAddressChanged()
{
    $changed = false;
    // Street
    $changed = $changed || $this->isColumnModified(COL_STREET);
    // Zip
    $changed = $changed || $this->isColumnModified(COL_ZIP);
    // City
    $changed = $changed || $this->isColumnModified(COL_CITY);

    return $changed;
}
```
(Constants are not Prefixed with class name).

Fixed it to generate the following code:
```php
/**
 * Check whether the address of this object has changed.
 *
 * @return boolean
 */
public function hasAddressChanged()
{
    $changed = false;
    // Street
    $changed = $changed || $this->isColumnModified(TableMap::COL_STREET);
    // Zip
    $changed = $changed || $this->isColumnModified(TableMap::COL_ZIP);
    // City
    $changed = $changed || $this->isColumnModified(TableMap::COL_CITY);

    return $changed;
}
```
